### PR TITLE
Introduce tidyUp method to remove old features

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.ts]
+indent_size = 4
+indent_style = space

--- a/spec/FeatureToggleService.spec.ts
+++ b/spec/FeatureToggleService.spec.ts
@@ -3,6 +3,7 @@ import { FeatureToggleService } from '../src/FeatureToggleService';
 describe('Feature toggling', () => {
     beforeEach(() => {
         localStorage.clear();
+        FeatureToggleService.clearFeatureList();
     });
 
     it('can register a feature', () => {
@@ -32,7 +33,7 @@ describe('Feature toggling', () => {
         expect(JSON.parse(localStorage.getItem('_feature.foo')).enabled).toBe(true);
     });
 
-    it('it considers a feature disabled if it is not set to on', () => {
+    it('considers a feature disabled if it is not set to on', () => {
         const service = new FeatureToggleService();
 
         service.register({
@@ -43,7 +44,7 @@ describe('Feature toggling', () => {
         expect(service.check('foo')).toBe(false);
     });
 
-    it('it considers a feature disabled if the localStorage key is missing', () => {
+    it('considers a feature disabled if the localStorage key is missing', () => {
         const service = new FeatureToggleService();
 
         service.register({
@@ -56,7 +57,7 @@ describe('Feature toggling', () => {
         expect(service.check('foo')).toBe(false);
     });
 
-    it('it considers a feature enabled if it is set to on', () => {
+    it('considers a feature enabled if it is set to on', () => {
         const service = new FeatureToggleService();
 
         service.register({
@@ -70,5 +71,24 @@ describe('Feature toggling', () => {
         }));
 
         expect(service.check('foo')).toBe(true);
+    });
+
+    describe('tidyUp method', () => {
+        it('removes the features that is not registered from localStorage', () => {
+            localStorage.setItem('_feature.some_old_feature', JSON.stringify({
+                name: 'Old feature that we will no longer register',
+                enabled: true,
+            }));
+
+            const service = new FeatureToggleService();
+            service.register({
+                name: 'Some new feature',
+                key: 'some_new_feature',
+            });
+
+            service.tidyUp();
+
+            expect(localStorage.getItem('_feature.some_old_feature')).toBeNull();
+        });
     });
 });

--- a/spec/FeatureToggleService.spec.ts
+++ b/spec/FeatureToggleService.spec.ts
@@ -86,7 +86,7 @@ describe('Feature toggling', () => {
                 key: 'some_new_feature',
             });
 
-            service.tidyUp();
+            service.tidyUpLocalStorageData();
 
             expect(localStorage.getItem('_feature.some_old_feature')).toBeNull();
         });

--- a/spec/FeatureToggleService.spec.ts
+++ b/spec/FeatureToggleService.spec.ts
@@ -3,7 +3,7 @@ import { FeatureToggleService } from '../src/FeatureToggleService';
 describe('Feature toggling', () => {
     beforeEach(() => {
         localStorage.clear();
-        FeatureToggleService.clearFeatureList();
+        FeatureToggleService.clearInternalFeatureList();
     });
 
     it('can register a feature', () => {

--- a/src/FeatureToggleService.ts
+++ b/src/FeatureToggleService.ts
@@ -12,6 +12,10 @@ export class FeatureToggleService {
         localStorage.setItem('_feature._enabled', JSON.stringify(true));
     }
 
+    static clearFeatureList() {
+        features.clear();
+    }
+
     register(feature: Feature) {
         if (!feature.name) {
             feature.name = feature.key;
@@ -25,6 +29,23 @@ export class FeatureToggleService {
         if (localStorage.getItem(this.localStorageKey(feature.key)) === null) {
             localStorage.setItem(this.localStorageKey(feature.key), JSON.stringify({ name: feature.name, enabled: false }));
         }
+    }
+
+    tidyUp() {
+        const registeredFeatures = Array.from(features.keys());
+        const keysInLocalStorage = Object.keys(localStorage)
+            .filter(key =>
+                key.startsWith(this.localStoragePrefix) &&
+                key !== `${this.localStoragePrefix}._enabled`
+            );
+
+        keysInLocalStorage.forEach(key => {
+           const feature = key.replace(`${this.localStoragePrefix}.`, '');
+
+           if (registeredFeatures.indexOf(feature) === -1) {
+               localStorage.removeItem(key);
+           }
+        });
     }
 
     check(featureKey: string): boolean {

--- a/src/FeatureToggleService.ts
+++ b/src/FeatureToggleService.ts
@@ -37,7 +37,13 @@ export class FeatureToggleService {
         }
     }
 
-    tidyUp() {
+    /**
+     * This method is used to tidy up localStorage. It will remove any features
+     * that are no longer registered.
+     *
+     * You should only call this method after registering all features.
+     */
+    tidyUpLocalStorageData() {
         const registeredFeatures = Array.from(features.keys());
         const keysInLocalStorage = Object.keys(localStorage)
             .filter(key =>

--- a/src/FeatureToggleService.ts
+++ b/src/FeatureToggleService.ts
@@ -12,7 +12,13 @@ export class FeatureToggleService {
         localStorage.setItem('_feature._enabled', JSON.stringify(true));
     }
 
-    static clearFeatureList() {
+    /**
+     * Clears the internal feature list. This only exists to be used in tests.
+     * Do not use in production code. No really, don't.
+     *
+     * @private
+     */
+    static clearInternalFeatureList() {
         features.clear();
     }
 


### PR DESCRIPTION
## Problem & background

Using this library combined with the related Chrome extension has led to a very messy localStorage data in Jobilla employee's computers, and consequently a very messy toggle list in the browser extension's view.

## Solution

Proposed solution is a new method called `tidyUp()` (name suggestions welcome). In summary, it removes all features from the local storage that were registered in previous session but not in the current session.

This method shall be called by the consumer application after their feature registers are done.

**How it works:** Since the library keeps internal track of what features are registered in the session, the new method can determine which features in local storage are from previous sessions.